### PR TITLE
Critical bugfixes and housekeeping 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+cmake-build-debug/
+.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,23 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(testapp LANGUAGES C)
-project(prodapp LANGUAGES C)
+project(sculpt LANGUAGES C)
 
-add_executable(testapp
-    src/sculpt.h
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_library(sculpt STATIC
     src/sculpt_mgr.c
     src/sculpt_util.c
     src/sculpt_header.c
     src/sculpt_conn.c
     src/sculpt_pool.c
-    app.c
 )
 
-#add_executable(prodapp
-#    prod/sculpt.h
-#    prod/sculpt.c
-#    app.c
-#)
+target_include_directories(sculpt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+add_executable(testapp app.c)
+target_link_libraries(testapp PRIVATE sculpt)
+
+add_executable(custom_protocol_example examples/custom_protocol/app.c)
+target_link_libraries(custom_protocol_example PRIVATE sculpt)
 
 install(TARGETS testapp RUNTIME DESTINATION bin)

--- a/app.c
+++ b/app.c
@@ -18,14 +18,6 @@
 #define URI_BUF 128
 #define AUTH_BUF 128
 
-typedef struct custom_protocol_data {
-    char uri[URI_BUF];
-    char method;
-    int content_len;
-    char connection_state;
-    char auth[AUTH_BUF];
-} protocol_data;
-
 static bool s_exit_flag = false;
 
 static void signal_handler(int sig) {
@@ -33,148 +25,7 @@ static void signal_handler(int sig) {
     s_exit_flag = true;
 }
 
-void protocol_fallback(sc_conn_mgr *mgr, sc_conn *conn, sc_http_msg msg, sc_headers *headers, void *extra_data, int err) {
-    if (err == SC_CONN_CLOSE) { // if the handler requests a connection close, we do so
-        sc_mgr_conn_release(mgr, conn);
-        return;
-    }
-
-    sc_error_log(mgr, SC_LL_MINIMAL, "Error code: %d\n", err);
-    const char *response = "50000000021|Internal Server Error";
-    send(conn->fd, response, strlen(response), 0);
-    if (conn->persistent) {
-        sc_mgr_conn_readd(mgr, conn);
-    } else {
-        sc_mgr_conn_release(mgr, conn);
-    }
-}
-
-int protocol_handler(sc_conn *conn, sc_http_msg *msg, sc_headers **headers, void **extra_data) {
-    *extra_data = malloc(sizeof(protocol_data));
-    if (*extra_data == NULL) {
-        return SC_MALLOC_ERR;
-    }
-
-    protocol_data *p_data = (protocol_data*) *extra_data;  
-
-    size_t uri_buf_size = 0;
-    size_t auth_buf_size = 0;
-
-    // parse URI
-    while (1) {
-        if (uri_buf_size > URI_BUF - 1) {
-            free(*extra_data);
-            return SC_BUFFER_OVERFLOW_ERR;
-        }
-
-        ssize_t bytes_read = read(conn->fd, &p_data->uri[uri_buf_size], 1);
-        if (bytes_read > 0) {
-            if (p_data->uri[uri_buf_size] == '|') {
-                // we got to the end of the uri
-                p_data->uri[uri_buf_size] = '\0';
-                break;
-            }
-            uri_buf_size++;
-        } else if (bytes_read == 0) {
-            printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");
-            free(*extra_data);
-            return SC_CONN_CLOSE; // signal to close the connection
-        } else {
-            p_data->uri[uri_buf_size+1] = '\0';
-            printf("Error reading URI; URI read so far: %s\n", p_data->uri);
-            free(*extra_data);
-            return SC_READ_ERR;
-        }
-    }
-
-    // parse method
-    ssize_t bytes_read = read(conn->fd, &p_data->method, 1);
-    if (bytes_read == 0) {
-        printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");
-        free(*extra_data);
-        return SC_CONN_CLOSE;
-    } else if (bytes_read != 1) {
-        free(*extra_data);
-        return SC_READ_ERR;
-    } 
-
-    // parse content-length
-    char content_len_buf[8];
-
-    bytes_read = read(conn->fd, content_len_buf, 8);
-    if (bytes_read == 0) {
-        printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");       
-        free(*extra_data);
-        return SC_CONN_CLOSE;
-    } else if (bytes_read != 8) {
-        free(*extra_data);
-        return SC_MALFORMED_HEADER_ERR;
-    }
-    p_data->content_len = atoi(content_len_buf);
-
-    // parses connection state
-    bytes_read = read(conn->fd, &p_data->connection_state, 1);
-    if (bytes_read == 0) {
-        printf("[OPSC protocol] Connection sent 0 bytes, sending close signal\n");  
-        free(*extra_data);
-        return SC_CONN_CLOSE;
-    } else if (bytes_read != 1) {
-        free(*extra_data);
-        return SC_READ_ERR;
-    }
-
-    conn->persistent = true;
-    if (p_data->connection_state == 'C' || p_data->connection_state == 'c') {
-        conn->persistent = false;
-    }
-
-    // read divisor (|)
-
-    char buffer[1];
-    read(conn->fd, buffer, 1);
-    printf("Throwing out %c\n", buffer[0]);
-
-
-    msg->method = sc_str_copy_n(&p_data->method, 1);
-    msg->uri = sc_str_copy_n(p_data->uri, strlen(p_data->uri));
-    msg->version = sc_str_copy_n("-1", 2);
-
-    return SC_OK;
-}
-
 void root_handler(int fd, sc_http_msg msg, sc_headers *headers, void *extra_data) {
-    protocol_data *p_data = (protocol_data*) extra_data;
-    size_t response_len = p_data->content_len + strlen(p_data->uri) + 10 + 12 + 200;
-    if (response_len >= BODY_BUF) {
-       send(fd, "40000000011|Bad Request", 23, 0);
-       return;
-    }
-    
-    char response[BODY_BUF];
-    char body[BODY_BUF];
-    ssize_t bytes_read = read(fd, body, p_data->content_len + 1);
-    if (bytes_read <= 0) {
-        printf("Bytes read: %lo\n", bytes_read);
-        const char *response = "50000000021|Internal Server Error";
-        send(fd, response, strlen(response), 0);
-        return;
-    }
-
-    // flush the fd for good measure
-    char buffer[1024];
-    while ((bytes_read = recv(fd, buffer, sizeof(buffer), 0)) > 0) {
-        // Discard data by doing nothing with `buffer`
-    }
-
-
-    body[bytes_read] = '\0';
-    snprintf(response, BODY_BUF, "200%08d|body:%s;uri:%s;method:%c;content-len:%d;conn-state:%c", 321, body, p_data->uri, p_data->method, p_data->content_len, p_data->connection_state);
-    printf("Sending response: %s\n", response);
-    send(fd, response, strlen(response), 0);
-}
-
-
-void root_handler_http(int fd, sc_http_msg msg, sc_headers *headers, void *extra_data) {
     if (strncmp(msg.method.buf, "OPTIONS", strlen("OPTIONS")) == 0) {
         const char *cors_msg = 
             "HTTP/1.1 204 No Content\r\n"
@@ -244,13 +95,10 @@ int main() {
         exit(EXIT_FAILURE);
     }
 
-    sc_mgr_bind_soft(mgr, "/", root_handler_http);
+    sc_mgr_bind_soft(mgr, "/", root_handler);
 
     sc_mgr_ll_set(mgr, SC_LL_DEBUG);
     sc_mgr_conn_recycling_set(mgr, true);
-    //mgr->protocol = SC_PROTOCOL_CUSTOM;
-    mgr->protocol_handler = protocol_handler;
-    mgr->protocol_fallback = protocol_fallback;
     
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);

--- a/app.c
+++ b/app.c
@@ -10,7 +10,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#include "src/sculpt.h"
+#include "sculpt.h"
 
 #define PORT 8000
 #define BACKLOG 128

--- a/examples/custom_protocol/app.c
+++ b/examples/custom_protocol/app.c
@@ -1,0 +1,226 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netdb.h>
+#include <sys/signal.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "sculpt.h"
+
+#define PORT 8000
+#define BACKLOG 128
+#define BODY_BUF 4096
+#define URI_BUF 128
+#define AUTH_BUF 128
+
+typedef struct custom_protocol_data {
+    char uri[URI_BUF];
+    char method;
+    int content_len;
+    char connection_state;
+    char auth[AUTH_BUF];
+} protocol_data;
+
+static bool s_exit_flag = false;
+
+static void signal_handler(int sig) {
+    signal(sig, signal_handler);
+    s_exit_flag = true;
+}
+
+void protocol_fallback(sc_conn_mgr *mgr, sc_conn *conn, sc_http_msg msg, sc_headers *headers, void *extra_data, int err) {
+    if (err == SC_CONN_CLOSE) { // if the handler requests a connection close, we do so
+        sc_mgr_conn_release(mgr, conn);
+        return;
+    }
+
+    sc_error_log(mgr, SC_LL_MINIMAL, "Error code: %d\n", err);
+    const char *response = "50000000021|Internal Server Error";
+    send(conn->fd, response, strlen(response), 0);
+    if (conn->persistent) {
+        sc_mgr_conn_readd(mgr, conn);
+    } else {
+        sc_mgr_conn_release(mgr, conn);
+    }
+}
+
+int protocol_handler(sc_conn *conn, sc_http_msg *msg, sc_headers **headers, void **extra_data) {
+    *extra_data = malloc(sizeof(protocol_data));
+    if (*extra_data == NULL) {
+        return SC_MALLOC_ERR;
+    }
+
+    protocol_data *p_data = (protocol_data*) *extra_data;  
+
+    size_t uri_buf_size = 0;
+    size_t auth_buf_size = 0;
+
+    // parse URI
+    while (1) {
+        if (uri_buf_size > URI_BUF - 1) {
+            free(*extra_data);
+            return SC_BUFFER_OVERFLOW_ERR;
+        }
+
+        ssize_t bytes_read = read(conn->fd, &p_data->uri[uri_buf_size], 1);
+        if (bytes_read > 0) {
+            if (p_data->uri[uri_buf_size] == '|') {
+                // we got to the end of the uri
+                p_data->uri[uri_buf_size] = '\0';
+                break;
+            }
+            uri_buf_size++;
+        } else if (bytes_read == 0) {
+            printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");
+            free(*extra_data);
+            return SC_CONN_CLOSE; // signal to close the connection
+        } else {
+            p_data->uri[uri_buf_size+1] = '\0';
+            printf("Error reading URI; URI read so far: %s\n", p_data->uri);
+            free(*extra_data);
+            return SC_READ_ERR;
+        }
+    }
+
+    // parse method
+    ssize_t bytes_read = read(conn->fd, &p_data->method, 1);
+    if (bytes_read == 0) {
+        printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");
+        free(*extra_data);
+        return SC_CONN_CLOSE;
+    } else if (bytes_read != 1) {
+        free(*extra_data);
+        return SC_READ_ERR;
+    } 
+
+    // parse content-length
+    char content_len_buf[8];
+
+    bytes_read = read(conn->fd, content_len_buf, 8);
+    if (bytes_read == 0) {
+        printf("[OPSC protocol] Connection sent 0 bytes, closing it\n");       
+        free(*extra_data);
+        return SC_CONN_CLOSE;
+    } else if (bytes_read != 8) {
+        free(*extra_data);
+        return SC_MALFORMED_HEADER_ERR;
+    }
+    p_data->content_len = atoi(content_len_buf);
+
+    // parses connection state
+    bytes_read = read(conn->fd, &p_data->connection_state, 1);
+    if (bytes_read == 0) {
+        printf("[OPSC protocol] Connection sent 0 bytes, sending close signal\n");  
+        free(*extra_data);
+        return SC_CONN_CLOSE;
+    } else if (bytes_read != 1) {
+        free(*extra_data);
+        return SC_READ_ERR;
+    }
+
+    conn->persistent = true;
+    if (p_data->connection_state == 'C' || p_data->connection_state == 'c') {
+        conn->persistent = false;
+    }
+
+    // read divisor (|)
+
+    char buffer[1];
+    read(conn->fd, buffer, 1);
+    printf("Throwing out %c\n", buffer[0]);
+
+
+    msg->method = sc_str_copy_n(&p_data->method, 1);
+    msg->uri = sc_str_copy_n(p_data->uri, strlen(p_data->uri));
+    msg->version = sc_str_copy_n("-1", 2);
+
+    return SC_OK;
+}
+
+void root_handler(int fd, sc_http_msg msg, sc_headers *headers, void *extra_data) {
+    protocol_data *p_data = (protocol_data*) extra_data;
+    size_t response_len = p_data->content_len + strlen(p_data->uri) + 10 + 12 + 200;
+    if (response_len >= BODY_BUF) {
+       send(fd, "40000000011|Bad Request", 23, 0);
+       return;
+    }
+    
+    char response[BODY_BUF];
+    char body[BODY_BUF];
+    ssize_t bytes_read = read(fd, body, p_data->content_len + 1);
+    if (bytes_read <= 0) {
+        printf("Bytes read: %lo\n", bytes_read);
+        const char *response = "50000000021|Internal Server Error";
+        send(fd, response, strlen(response), 0);
+        return;
+    }
+
+    // flush the fd for good measure
+    char buffer[1024];
+    while ((bytes_read = recv(fd, buffer, sizeof(buffer), 0)) > 0) {
+        // Discard data by doing nothing with `buffer`
+    }
+
+
+    body[bytes_read] = '\0';
+    snprintf(response, BODY_BUF, "200%08d|body:%s;uri:%s;method:%c;content-len:%d;conn-state:%c", 321, body, p_data->uri, p_data->method, p_data->content_len, p_data->connection_state);
+    printf("Sending response: %s\n", response);
+    send(fd, response, strlen(response), 0);
+}
+
+int main() {    
+    // create and setup socket    
+    sc_addr_info addr_info = sc_addr_create(AF_INET, 8000, INADDR_ANY);
+
+    int error;
+    sc_conn_mgr *mgr = sc_mgr_create(addr_info, &error);
+    if (mgr == NULL) {
+        fprintf(stderr, "Error on create: %d", error);
+        exit(EXIT_FAILURE);
+    }
+    
+    error = sc_mgr_epoll_init(mgr);
+    if (error != SC_OK) {
+        fprintf(stderr, "Error initializing epoll: %d", error);
+        sc_mgr_finish(mgr);
+        exit(EXIT_FAILURE);
+    }
+
+    error = sc_mgr_conn_pool_init(mgr, 3);
+    if (error != SC_OK) {
+        fprintf(stderr, "Error initializing connection pool: %d", error);
+        sc_mgr_finish(mgr);
+        exit(EXIT_FAILURE);
+    }
+
+    error = sc_mgr_listen(mgr);
+    if (error != SC_OK) {
+        fprintf(stderr, "Error on listen: %d", error);
+        sc_mgr_finish(mgr);
+        exit(EXIT_FAILURE);
+    }
+
+    sc_mgr_bind_soft(mgr, "/", root_handler);
+
+    sc_mgr_ll_set(mgr, SC_LL_DEBUG);
+    sc_mgr_conn_recycling_set(mgr, true);
+    mgr->protocol = SC_PROTOCOL_CUSTOM;
+    mgr->protocol_handler = protocol_handler;
+    mgr->protocol_fallback = protocol_fallback;
+    
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    while (!s_exit_flag) {
+        sc_mgr_poll(mgr, 1000);
+    }
+
+    sc_mgr_finish(mgr);
+
+    return 0;
+}

--- a/src/sculpt_conn.c
+++ b/src/sculpt_conn.c
@@ -167,7 +167,9 @@ int next_header(sc_conn_mgr *mgr, int fd, char *header, size_t buf_len) {
     char last_char = '\0';
 
     while (1) {
-        if (header_len > buf_len) { // stop if the header is larger than the buffer
+        // stop if the header is larger than the buffer
+        // only checking header_len > buf_len could lead to a two-byte overflow, since it reads into header[buf_len] and writes `\0` at buf_len + 1
+        if (header_len >= buf_len - 1) {
             return SC_BUFFER_OVERFLOW_ERR;
         }
 

--- a/src/sculpt_conn.c
+++ b/src/sculpt_conn.c
@@ -222,7 +222,7 @@ int get_http_msg(sc_conn_mgr *mgr, char *header, sc_http_msg *http_msg) {
 
     // find method in header
     size_t method_len = space - header;
-    if (method_len == 0 || method_len > METHOD_BUF_SIZE) {
+    if (method_len == 0 || method_len >= METHOD_BUF_SIZE) {
         sc_error_log(mgr, SC_LL_NORMAL, "[Sculpt] The header passed to get_http_msg was malformed, as it had a method that was too long\n");
         return SC_BUFFER_OVERFLOW_ERR;
     }
@@ -243,7 +243,7 @@ int get_http_msg(sc_conn_mgr *mgr, char *header, sc_http_msg *http_msg) {
     }
 
     size_t uri_len = space - uri_start;
-    if (uri_len == 0 || uri_len > URL_BUF_SIZE) {
+    if (uri_len == 0 || uri_len >= URL_BUF_SIZE) {
         sc_error_log(mgr, SC_LL_NORMAL, "[Sculpt] The header passed to get_http_msg was malformed, as it had a uri that exceeded the max buffer size\n");
         return SC_BUFFER_OVERFLOW_ERR;
     }
@@ -264,7 +264,7 @@ int get_http_msg(sc_conn_mgr *mgr, char *header, sc_http_msg *http_msg) {
     }
 
     size_t version_len = end - version_start;
-    if (version_len == 0 || version_len > VERSION_BUF_SIZE) {
+    if (version_len == 0 || version_len >= VERSION_BUF_SIZE) {
         sc_error_log(mgr, SC_LL_NORMAL, "[Sculpt] The header passed to get_http_msg was malformed, as it had a uri that exceeded the max buffer size\n");
         return SC_BUFFER_OVERFLOW_ERR;
     }

--- a/src/sculpt_conn.c
+++ b/src/sculpt_conn.c
@@ -58,7 +58,7 @@ static int create_new_connection(sc_conn_mgr *mgr) {
     }
 
     // valid connection was found, so we accept the request
-     conn->fd = accept(mgr->fd, (struct sockaddr*)&mgr->addr_info._sock_addr, &addr_len);
+    conn->fd = accept(mgr->fd, (struct sockaddr*)&mgr->addr_info._sock_addr, &addr_len);
 
     if (conn->fd == -1) {
         sc_perror(mgr,  SC_LL_NORMAL, "[Sculpt] Error on Accept. Checking severity\n");
@@ -404,7 +404,6 @@ int sc_mgr_poll(sc_conn_mgr *mgr, int timeout_ms) {
                 sc_headers *headers = NULL;
                 void *extra_data = NULL;
                 if (mgr->protocol == SC_PROTOCOL_HTTP) { // parsing of HTTP headers
-                    sc_headers *headers = NULL;
                     int err = parse_all_headers(mgr, conn, &headers, &http_msg);
                     
                     if (err == SC_MALFORMED_HEADER_ERR || err == SC_BUFFER_OVERFLOW_ERR) {

--- a/src/sculpt_pool.c
+++ b/src/sculpt_pool.c
@@ -54,7 +54,7 @@ sc_conn *sc_mgr_conn_get_free(sc_conn_mgr *mgr) {
         
         sc_log(mgr, SC_LL_DEBUG, "All connections are being used; releasing the oldest inactive one.\n");
         
-        sc_conn *oldest;
+        sc_conn *oldest = &mgr->conn_pool[0];
         time_t oldest_time = time(NULL);
         for (size_t i = 0; i < mgr->max_conn_count; i++) {
             sc_conn *conn = &mgr->conn_pool[i];


### PR DESCRIPTION
- Tidied up CMake configs to define sculpt as a target library
- Created `examples` with dedicated example for the custom protocol
- Four simple, critical fixes:
1. fixed shadowed `sc_headers *headers` declaration
2. fixed possible null pointer access on connection recycling if all connections were just as old as each other
3. fixed off-by-one string parsing errors on http_msg parser
4. fixed off-by-two string parsing error on http header parset